### PR TITLE
Docs: Add Authentication Server API Documentation

### DIFF
--- a/AUTH_SERVER_API_EN.md
+++ b/AUTH_SERVER_API_EN.md
@@ -1,0 +1,227 @@
+```markdown
+# ApFree WiFiDog - Authentication Server API Documentation
+
+This document details the communication interfaces between ApFree WiFiDog and the Authentication Server.
+
+## 1. Ping Interface
+
+This interface is used by ApFree WiFiDog to periodically inform the authentication server that it is active and to report basic system status.
+
+*   **Method:** `GET`
+*   **Path:** Constructed from `auth_server_path` + `auth_server_ping_script_path_fragment` (configurable in `wifidog.conf`).
+*   **Frequency:** Typically every 60 seconds.
+*   **Query Parameters:**
+    *   `device_id`: (string) Unique identifier of the WiFiDog gateway.
+    *   `sys_uptime`: (long) System uptime in seconds.
+    *   `sys_memfree`: (unsigned int) Free system memory in Kilobytes.
+    *   `sys_load`: (float) System load average (1-minute).
+    *   `nf_conntrack_count`: (long) Netfilter connection track count.
+    *   `cpu_usage`: (double) CPU utilization percentage.
+    *   `wifidog_uptime`: (long) WiFiDog process uptime in seconds.
+    *   `online_clients`: (int) Number of currently authenticated clients.
+    *   `offline_clients`: (int) Number of recently disconnected clients that have aged out.
+    *   `ssid`: (string) The primary SSID of the gateway (URL encoded). Defaults to "NULL".
+    *   `fm_version`: (string) Firmware version of the device. Defaults to "null".
+    *   `type`: (string) Device board type. Defaults to "null".
+    *   `name`: (string) Device board name. Defaults to "null".
+    *   `wired_passed`: (int) 1 if wired clients bypass portal, 0 otherwise.
+    *   `aw_version`: (string) ApFree WiFiDog software version.
+
+*   **Server Response:**
+    *   **Success:** The response body must contain the string "Pong".
+    *   **Action on Success:** WiFiDog marks the auth server as online. If previously marked down, firewall rules are updated.
+    *   **Failure:** If "Pong" is not found, or if there's a connection error, WiFiDog marks the auth server as offline, and firewall rules may be updated to handle auth server unavailability (e.g., block clients or allow all).
+
+## 2. Counters Interface (Version 2)
+
+This interface is used by ApFree WiFiDog to periodically send detailed counter information for all connected clients to the authentication server. The server can then respond with actions for specific clients (e.g., disconnect).
+
+*   **Method:** `POST`
+*   **Path:** Constructed from `auth_server_path` + `auth_server_auth_script_path_fragment`.
+*   **Query Parameter on Path:** `stage=counters_v2`
+*   **Frequency:** Typically every `checkinterval` (e.g., 60 seconds).
+*   **Request Body:** `application/json`
+    ```json
+    {
+      "device_id": "string", // Unique identifier of the WiFiDog gateway
+      "gateway": [
+        {
+          "gw_id": "string",      // Gateway ID
+          "gw_channel": "string", // Gateway channel
+          "clients": [
+            {
+              "id": "integer",                // WiFiDog's internal client ID
+              "ip": "string",                 // Client IPv4 address
+              "ip6": "string",                // Client IPv6 address (or "N/A")
+              "mac": "string",                // Client MAC address
+              "token": "string",              // Client's authentication token
+              "name": "string",               // Client name (or "N/A")
+              "incoming_bytes": "long long",
+              "outgoing_bytes": "long long",
+              "incoming_rate": "long long",   // Bytes/sec
+              "outgoing_rate": "long long",   // Bytes/sec
+              "incoming_packets": "long long",
+              "outgoing_packets": "long long",
+              "incoming_bytes_v6": "long long",
+              "outgoing_bytes_v6": "long long",
+              "incoming_rate_v6": "long long", // Bytes/sec
+              "outgoing_rate_v6": "long long", // Bytes/sec
+              "incoming_packets_v6": "long long",
+              "outgoing_packets_v6": "long long",
+              "first_login": "long long",     // Timestamp of client's first login
+              "is_online": "boolean",         // Current online status known to WiFiDog
+              "wired": "boolean"              // True if the client is on a wired connection
+            }
+            // ... more client objects
+          ]
+        }
+        // ... more gateway objects (usually one for a single device)
+      ]
+    }
+    ```
+
+*   **Server Response:** `application/json`
+    ```json
+    {
+      "result": [
+        {
+          "gw_id": "string", // Gateway ID this operation applies to
+          "auth_op": [
+            {
+              "id": "integer",        // WiFiDog's internal client ID to act upon
+              "auth_code": "integer"  // Action code for this client
+            }
+            // ... more auth_op objects for other clients
+          ]
+        }
+        // ... more result objects
+      ]
+    }
+    ```
+    *   **`auth_code` values and WiFiDog actions:**
+        *   `0` (AUTH_ALLOWED): Client is allowed. If previously in validation, counters might be reset.
+        *   `1` (AUTH_DENIED): Client is denied. Firewall rules are applied to block the client, and the client is removed from WiFiDog's active list.
+        *   `2` (AUTH_VALIDATION): Client is in a validation period (e.g., email verification pending). Access might be restricted.
+        *   `5` (AUTH_VALIDATION_FAILED): Validation failed or timed out. Client is denied, firewall rules applied, and client removed.
+        *   Other codes might exist for specific error conditions.
+
+## 3. WebSocket Interface
+
+This interface provides a persistent, real-time communication channel between ApFree WiFiDog and the authentication server.
+
+### 3.1. Connection Establishment
+
+1.  **HTTP Upgrade Request (Client to Server):**
+    *   **Method:** `GET`
+    *   **Path:** Configured via `ws_server_path` in `wifidog.conf`.
+    *   **Headers:**
+        *   `Host`: `<ws_server_hostname>:<ws_server_port>`
+        *   `User-Agent`: `apfree-wifidog`
+        *   `Upgrade`: `websocket`
+        *   `Connection`: `upgrade`
+        *   `Sec-WebSocket-Key`: Randomly generated 24-byte Base64 string.
+        *   `Sec-WebSocket-Version`: `13`
+
+2.  **HTTP Upgrade Response (Server to Client):**
+    *   **Status Code:** `101 Switching Protocols`
+    *   **Headers:**
+        *   `Upgrade`: `websocket`
+        *   `Connection`: `Upgrade`
+        *   `Sec-WebSocket-Accept`: Server's computed accept key (SHA1 hash of client's `Sec-WebSocket-Key` concatenated with a standard GUID, then Base64 encoded).
+
+### 3.2. Client to Server Messages (JSON Payloads via WebSocket TEXT_FRAME)
+
+1.  **Initial "Connect" Message:**
+    *   Sent immediately after successful WebSocket upgrade.
+    *   **JSON Structure:**
+        ```json
+        {
+          "type": "connect",
+          "device_id": "string", // WiFiDog gateway's unique ID
+          "gateway": [
+            {
+              "gw_id": "string",
+              "gw_channel": "string",
+              "gw_address_v4": "string",
+              "auth_mode": "integer", // Current authentication mode of the gateway
+              "gw_interface": "string",
+              "gw_address_v6": "string" // (Optional)
+            }
+            // ... more gateway objects if configured
+          ]
+        }
+        ```
+
+2.  **Periodic "Heartbeat" Message:**
+    *   Sent every 60 seconds.
+    *   **JSON Structure:** Same as the "connect" message, but with `"type": "heartbeat"`.
+        ```json
+        {
+          "type": "heartbeat",
+          "device_id": "string",
+          "gateway": [ /* ... same structure as connect ... */ ]
+        }
+        ```
+
+### 3.3. Server to Client Messages (JSON Payloads via WebSocket TEXT_FRAME)
+
+WiFiDog parses incoming messages based on the `"type"` field in the JSON payload.
+
+1.  **Type: "heartbeat" or "connect" (Response from Server)**
+    *   This is the server's acknowledgment/response to client's connect/heartbeat.
+    *   **JSON Structure:**
+        ```json
+        {
+          "type": "heartbeat", // or "connect"
+          "gateway": [
+            {
+              "gw_id": "string",
+              "auth_mode": "integer" // New auth mode for this gateway
+            }
+            // ... more gateway objects
+          ]
+        }
+        ```
+    *   **WiFiDog Action:** Updates the local `auth_mode` for each specified `gw_id`. If any mode changes, firewall rules may be reloaded.
+
+2.  **Type: "auth" (Server Grants Authentication)**
+    *   **JSON Structure:**
+        ```json
+        {
+          "type": "auth",
+          "token": "string",         // Authentication token for the client
+          "client_ip": "string",
+          "client_mac": "string",
+          "client_name": "string",   // (Optional)
+          "gw_id": "string",         // Gateway ID the client is on
+          "once_auth": "boolean"     // If true, special one-time auth handling
+        }
+        ```
+    *   **WiFiDog Action:**
+        *   If `once_auth` is true: Sets the specified gateway's `auth_mode` to 0 (bypass/no auth) and reloads firewall.
+        *   If `once_auth` is false: Adds the client to the authenticated list with the provided details, applies firewall rules to allow access.
+
+3.  **Type: "kickoff" (Server Requests Client Disconnection)**
+    *   **JSON Structure:**
+        ```json
+        {
+          "type": "kickoff",
+          "client_ip": "string",
+          "client_mac": "string",
+          "device_id": "string", // Must match WiFiDog's own device_id
+          "gw_id": "string"      // Must match the client's current gw_id
+        }
+        ```
+    *   **WiFiDog Action:** Validates `device_id` and `gw_id`. If correct and client exists, applies firewall rules to deny access and removes the client from the active list.
+
+4.  **Type: "tmp_pass" (Server Grants Temporary Access)**
+    *   **JSON Structure:**
+        ```json
+        {
+          "type": "tmp_pass",
+          "client_mac": "string",
+          "timeout": "integer" // (Optional) Access duration in seconds, defaults to 300
+        }
+        ```
+    *   **WiFiDog Action:** Grants temporary network access to the specified MAC address for the duration of the timeout by updating firewall rules.
+```

--- a/AUTH_SERVER_API_ZH.md
+++ b/AUTH_SERVER_API_ZH.md
@@ -1,0 +1,227 @@
+```markdown
+# ApFree WiFiDog - 认证服务器API文档
+
+本文档详细说明了 ApFree WiFiDog 与认证服务器之间的通信接口。
+
+## 1. Ping (心跳) 接口
+
+此接口供 ApFree WiFiDog 定期通知认证服务器其处于活动状态，并报告基本系统状态。
+
+*   **方法:** `GET`
+*   **路径:** 由 `auth_server_path` + `auth_server_ping_script_path_fragment` 构建 (在 `wifidog.conf` 中配置)。
+*   **频率:** 通常每 60 秒一次。
+*   **查询参数:**
+    *   `device_id`: (字符串) WiFiDog 网关的唯一标识符。
+    *   `sys_uptime`: (长整型) 系统运行时间 (秒)。
+    *   `sys_memfree`: (无符号整型) 系统空闲内存 (KB)。
+    *   `sys_load`: (浮点型) 系统平均负载 (1分钟)。
+    *   `nf_conntrack_count`: (长整型) Netfilter 连接跟踪计数。
+    *   `cpu_usage`: (双精度浮点型) CPU 使用率百分比。
+    *   `wifidog_uptime`: (长整型) WiFiDog 进程运行时间 (秒)。
+    *   `online_clients`: (整型) 当前在线客户端数量。
+    *   `offline_clients`: (整型) 最近断开连接并已老化的客户端数量。
+    *   `ssid`: (字符串) 网关的主 SSID (URL编码)。默认为 "NULL"。
+    *   `fm_version`: (字符串) 设备固件版本。默认为 "null"。
+    *   `type`: (字符串) 设备主板类型。默认为 "null"。
+    *   `name`: (字符串) 设备主板名称。默认为 "null"。
+    *   `wired_passed`: (整型) 如果有线客户端绕过门户则为1，否则为0。
+    *   `aw_version`: (字符串) ApFree WiFiDog 软件版本。
+
+*   **服务器响应:**
+    *   **成功:** 响应体必须包含字符串 "Pong"。
+    *   **成功操作:** WiFiDog 将认证服务器标记为在线。如果先前标记为离线，则更新防火墙规则。
+    *   **失败:** 如果未找到 "Pong"，或发生连接错误，WiFiDog 将认证服务器标记为离线，并可能更新防火墙规则以处理认证服务器不可用的情况 (例如，阻止客户端或允许所有客户端)。
+
+## 2. Counters (计数器) 接口 (V2 版本)
+
+此接口供 ApFree WiFiDog 定期向认证服务器发送所有已连接客户端的详细计数器信息。然后，服务器可以对特定客户端进行操作响应 (例如，断开连接)。
+
+*   **方法:** `POST`
+*   **路径:** 由 `auth_server_path` + `auth_server_auth_script_path_fragment` 构建。
+*   **路径中的查询参数:** `stage=counters_v2`
+*   **频率:** 通常每 `checkinterval` (例如 60 秒) 一次。
+*   **请求体:** `application/json`
+    ```json
+    {
+      "device_id": "字符串", // WiFiDog 网关的唯一标识符
+      "gateway": [
+        {
+          "gw_id": "字符串",      // 网关 ID
+          "gw_channel": "字符串", // 网关信道
+          "clients": [
+            {
+              "id": "整数",                  // WiFiDog 内部客户端 ID
+              "ip": "字符串",                // 客户端 IPv4 地址
+              "ip6": "字符串",               // 客户端 IPv6 地址 (或 "N/A")
+              "mac": "字符串",               // 客户端 MAC 地址
+              "token": "字符串",             // 客户端的认证令牌
+              "name": "字符串",              // 客户端名称 (或 "N/A")
+              "incoming_bytes": "长长整型",
+              "outgoing_bytes": "长长整型",
+              "incoming_rate": "长长整型",   // 字节/秒
+              "outgoing_rate": "长长整型",   // 字节/秒
+              "incoming_packets": "长长整型",
+              "outgoing_packets": "长长整型",
+              "incoming_bytes_v6": "长长整型",
+              "outgoing_bytes_v6": "长长整型",
+              "incoming_rate_v6": "长长整型", // 字节/秒
+              "outgoing_rate_v6": "长长整型", // 字节/秒
+              "incoming_packets_v6": "长长整型",
+              "outgoing_packets_v6": "长长整型",
+              "first_login": "长长整型",     // 客户端首次登录的时间戳
+              "is_online": "布尔型",         // WiFiDog 知晓的当前在线状态
+              "wired": "布尔型"              // 如果客户端是有线连接则为 true
+            }
+            // ... 更多客户端对象
+          ]
+        }
+        // ... 更多网关对象 (单个设备通常只有一个)
+      ]
+    }
+    ```
+
+*   **服务器响应:** `application/json`
+    ```json
+    {
+      "result": [
+        {
+          "gw_id": "字符串", // 此操作适用的网关 ID
+          "auth_op": [
+            {
+              "id": "整数",        // 需要操作的 WiFiDog 内部客户端 ID
+              "auth_code": "整数"  // 针对此客户端的操作代码
+            }
+            // ... 更多针对其他客户端的 auth_op 对象
+          ]
+        }
+        // ... 更多 result 对象
+      ]
+    }
+    ```
+    *   **`auth_code` 值及 WiFiDog 操作:**
+        *   `0` (AUTH_ALLOWED): 允许客户端。如果先前处于验证状态，计数器可能会被重置。
+        *   `1` (AUTH_DENIED): 拒绝客户端。应用防火墙规则以阻止客户端，并将客户端从 WiFiDog 的活动列表中移除。
+        *   `2` (AUTH_VALIDATION): 客户端处于验证阶段 (例如，等待邮件验证)。访问可能受限。
+        *   `5` (AUTH_VALIDATION_FAILED): 验证失败或超时。拒绝客户端，应用防火墙规则，并移除客户端。
+        *   其他代码可能用于特定的错误条件。
+
+## 3. WebSocket 接口
+
+此接口提供 ApFree WiFiDog 与认证服务器之间的持久性实时通信通道。
+
+### 3.1. 连接建立
+
+1.  **HTTP Upgrade 请求 (客户端到服务器):**
+    *   **方法:** `GET`
+    *   **路径:** 通过 `wifidog.conf` 中的 `ws_server_path` 配置。
+    *   **头部信息:**
+        *   `Host`: `<ws_server_hostname>:<ws_server_port>`
+        *   `User-Agent`: `apfree-wifidog`
+        *   `Upgrade`: `websocket`
+        *   `Connection`: `upgrade`
+        *   `Sec-WebSocket-Key`: 随机生成的24字节 Base64 字符串。
+        *   `Sec-WebSocket-Version`: `13`
+
+2.  **HTTP Upgrade 响应 (服务器到客户端):**
+    *   **状态码:** `101 Switching Protocols`
+    *   **头部信息:**
+        *   `Upgrade`: `websocket`
+        *   `Connection`: `Upgrade`
+        *   `Sec-WebSocket-Accept`: 服务器计算的接受密钥 (客户端 `Sec-WebSocket-Key` 与标准 GUID 串联后的 SHA1 哈希值，再进行 Base64 编码)。
+
+### 3.2. 客户端到服务器消息 (通过 WebSocket TEXT_FRAME 发送的 JSON 载荷)
+
+1.  **初始 "Connect" (连接) 消息:**
+    *   在 WebSocket 成功升级后立即发送。
+    *   **JSON 结构:**
+        ```json
+        {
+          "type": "connect", // 或 "heartbeat"
+          "device_id": "字符串", // WiFiDog 网关的唯一 ID
+          "gateway": [
+            {
+              "gw_id": "字符串",
+              "gw_channel": "字符串",
+              "gw_address_v4": "字符串",
+              "auth_mode": "整数", // 网关当前认证模式
+              "gw_interface": "字符串",
+              "gw_address_v6": "字符串" // (可选)
+            }
+            // ... 如果配置了多个网关，则有更多网关对象
+          ]
+        }
+        ```
+
+2.  **周期性 "Heartbeat" (心跳) 消息:**
+    *   每 60 秒发送一次。
+    *   **JSON 结构:** 与 "connect" 消息结构相同，但 `"type": "heartbeat"`。
+        ```json
+        {
+          "type": "heartbeat",
+          "device_id": "字符串",
+          "gateway": [ /* ... 与 connect 结构相同 ... */ ]
+        }
+        ```
+
+### 3.3. 服务器到客户端消息 (通过 WebSocket TEXT_FRAME 发送的 JSON 载荷)
+
+WiFiDog 根据 JSON 载荷中的 `"type"` 字段解析传入消息。
+
+1.  **Type: "heartbeat" 或 "connect" (服务器对客户端消息的响应)**
+    *   这是服务器对客户端 connect/heartbeat 消息的确认/响应。
+    *   **JSON 结构:**
+        ```json
+        {
+          "type": "heartbeat", // 或 "connect"
+          "gateway": [
+            {
+              "gw_id": "字符串",
+              "auth_mode": "整数" // 此网关的新认证模式
+            }
+            // ... 更多网关对象
+          ]
+        }
+        ```
+    *   **WiFiDog 操作:** 更新每个指定 `gw_id` 的本地 `auth_mode`。如果任何模式发生更改，可能会重新加载防火墙规则。
+
+2.  **Type: "auth" (服务器授予认证)**
+    *   **JSON 结构:**
+        ```json
+        {
+          "type": "auth",
+          "token": "字符串",         // 客户端的认证令牌
+          "client_ip": "字符串",
+          "client_mac": "字符串",
+          "client_name": "字符串",   // (可选)
+          "gw_id": "字符串",         // 客户端所在的网关 ID
+          "once_auth": "布尔型"     // 如果为 true，则为特殊的一次性认证处理
+        }
+        ```
+    *   **WiFiDog 操作:**
+        *   如果 `once_auth` 为 true: 将指定网关的 `auth_mode` 设置为 0 (绕过/无认证模式) 并重新加载防火墙。
+        *   如果 `once_auth` 为 false: 使用提供的详细信息将客户端添加到已认证列表，并应用防火墙规则以允许访问。
+
+3.  **Type: "kickoff" (服务器请求断开客户端连接)**
+    *   **JSON 结构:**
+        ```json
+        {
+          "type": "kickoff",
+          "client_ip": "字符串",
+          "client_mac": "字符串",
+          "device_id": "字符串", // 必须与 WiFiDog 自身的 device_id 匹配
+          "gw_id": "字符串"      // 必须与客户端当前的 gw_id 匹配
+        }
+        ```
+    *   **WiFiDog 操作:** 验证 `device_id` 和 `gw_id`。如果正确且客户端存在，则应用防火墙规则拒绝访问，并将客户端从活动列表中移除。
+
+4.  **Type: "tmp_pass" (服务器授予临时访问权限)**
+    *   **JSON 结构:**
+        ```json
+        {
+          "type": "tmp_pass",
+          "client_mac": "字符串",
+          "timeout": "整数" // (可选) 访问持续时间 (秒)，默认为 300
+        }
+        ```
+    *   **WiFiDog 操作:** 通过更新防火墙规则，为指定的 MAC 地址授予指定超时时间的临时网络访问权限。
+```

--- a/README-zh.md
+++ b/README-zh.md
@@ -31,53 +31,70 @@ ApFree WiFiDog 是一个开源的高性能认证门户解决方案，专门用�
 4. **长连接支持**：支持长连接，包括 WebSocket 和 MQTT，实现实时通信。
 5. **灵活的认证方式**：提供本地和云端认证，满足不同用户需求。
 6. **高级规则管理**：支持动态管理访问规则，包括 MAC 地址和 IP/域名，无需重启。
+7. **积极支持**：拥有积极活跃的社区支持及快速的问题响应。
+8. **eBPF流控与DPI**：利用eBPF实现高效的流量控制和深度包检测(DPI)功能。
 
 ### 安装
 
-在安装任何软件包之前，建议更新软件包列表：
-```bash
-opkg update
-```
+OpenWrt 的包管理器命令因版本而异。
 
-要在 OpenWrt 上安装 ApFree WiFiDog，请使用以下命令：
-```bash
-opkg install apfree-wifidog
-```
+**对于最新的 OpenWrt 版本 (通常使用 `apk`):**
+1. 更新软件包列表:
+   ```bash
+   apk update
+   ```
+2. 安装 ApFree WiFiDog:
+   ```bash
+   apk add apfree-wifidog
+   ```
 
-对于 LuCI Web 界面，请安装以下软件包：
-```bash
-opkg install luci-app-apfree-wifidog
-```
+**对于较旧的 OpenWrt 版本 (通常使用 `opkg`):**
+1. 更新软件包列表:
+   ```bash
+   opkg update
+   ```
+2. 安装 ApFree WiFiDog:
+   ```bash
+   opkg install apfree-wifidog
+   ```
+
+**LuCI Web 界面:**
+`luci-app-apfree-wifidog` 软件包 **不能** 使用上述命令安装。有关设置 LuCI Web 界面的指导，请参阅“LuCI 集成”部分，其中推荐使用 `chawrt` 项目，或者如果您正在构建自己的固件，则从主 `luci` 仓库集成 LuCI。
 
 ### LuCI 集成
 
-为简化配置，ApFree WiFiDog 包含 LuCI 界面。您可以通过 [luci-app-apfree-wifidog 仓库](https://github.com/liudf0716/luci-app-apfree-wifidog) 轻松管理设置。
+为了简化配置，ApFree WiFiDog 提供了 LuCI 界面。`luci-app-apfree-wifidog` 软件包之前是独立的，但现在已集成到主 `luci` 仓库中，地址为 [https://github.com/liudf0716/luci](https://github.com/liudf0716/luci)。
+
+**推荐设置:**
+我们建议用户采用 **`chawrt`** 项目来设置您的 OpenWrt 环境，该项目位于 [https://github.com/liudf0716/chawrt](https://github.com/liudf0716/chawrt)。`chawrt` 项目包含了 `luci-app-apfree-wifidog`，并提供了一个全面、即用型的 OpenWrt 固件解决方案，其中已集成了 ApFree WiFiDog。使用 `chawrt` 是开始使用完整配置系统的最简单方法。
+
+如果您正在构建自己的固件或偏好手动安装，您可以在上面提到的 `luci` 仓库中找到该 LuCI 应用程序。然而，对于大多数用户来说，**`chawrt`** 提供了更简化的体验。
 
 ### 基本用法示例：访客网络
 
-ApFree WiFiDog 的一个常见用例是设置访客 WiFi 网络，要求用户在获得完全互联网访问权限之前通过强制门户进行身份验证。以下是所涉及步骤的概述：
+推荐使用 `luci-app-apfree-wifidog` 网页界面来配置 ApFree WiFiDog，它提供了一种用户友好的方式来管理所有设置。不鼓励手动编辑配置文件。
 
-1.  **在 OpenWrt 中设置访客网络接口：**
-    *   这通常涉及在 OpenWrt 路由器的网络配置中创建一个新的网络接口（例如，`guestnet`）。
-    *   您可以将此接口分配给一个单独的 VLAN 或一个专门为访客提供的不同 WiFi SSID。
-    *   确保此访客网络已启用 DHCP 以向客户端分配 IP 地址，但最初不允许通过防火墙规则进行常规互联网访问（ApFree WiFiDog 将管理此问题）。
+以下是两种常见的应用场景：
 
-2.  **配置 ApFree WiFiDog：**
-    *   编辑 ApFree WiFiDog 配置文件（例如，`/etc/wifidog.conf` 或 `/etc/wifidogx.conf`）。
-    *   将 `GatewayInterface` 选项设置为您的访客网络接口的名称（例如，`GatewayInterface guestnet`）。
-    *   通过设置 `AuthServerHostname`、`AuthServerPort` 和 `AuthServerPath` 指向您的强制门户的认证服务来配置认证服务器详细信息。例如：
-        ```
-        AuthServerHostname auth.example.com
-        AuthServerPort 80
-        AuthServerPath /wifidog/
-        ```
+1.  **云认证方式:**
+    *   此模式需要外部认证服务器。
+    *   **通过 LuCI 配置步骤:**
+        *   在 LuCI 中导航到 ApFree WiFiDog 配置页面。
+        *   **认证服务器设置:** 配置认证服务器的 `主机名` (Hostname)、`端口` (Port) 和 `路径` (Path)。
+        *   **网关配置:** 确保 `网关接口` (Gateway Interface) 正确设置为您的访客网络接口 (例如 `br-guest`)。
+        *   **高级设置:** 为了支持实时通信和状态更新（云端方案通常需要），启用并配置 `WebSocket支持` (WebSocket Support) (例如，指定 WebSocket URL/路径)。
+    *   连接到访客网络的客户端将被重定向到您的云认证门户。成功认证后，他们将被授予互联网访问权限。
 
-3.  **客户端连接和重定向：**
-    *   当客户端连接到您的访客 WiFi 网络时，其 HTTP(S) 流量将被 ApFree WiFiDog 拦截。
-    *   他们将被重定向到您的 `AuthServer` 设置指定的认证门户。
-    *   成功认证后，ApFree WiFiDog 将根据认证服务器提供的规则和持续时间允许他们访问互联网。
+2.  **本地认证方式 (仅展示页面):**
+    *   此模式不需要外部认证服务器，通常用于较简单的场景，例如在授予访问权限之前显示欢迎页面或服务条款。
+    *   **通过 LuCI 配置步骤:**
+        *   在 LuCI 中导航到 ApFree WiFiDog 配置页面。
+        *   **网关配置:** 确保 `网关接口` (Gateway Interface) 正确设置为您的访客网络接口 (例如 `br-guest`)。
+        *   **认证模式:** 选择本地或展示页面模式（如果可用），或者确保没有配置外部 `AuthServer`。
+        *   **跳转URL / 展示页面URL:** 配置 `跳转URL` (Redirect URL) (或类似字段) 指向您期望的本地展示页面或外部信息页面。这是用户在被授予访问权限之前将看到的页面。对于简单的“点击继续”设置，这可能是您在路由器本身上托管的页面或一个简单的外部站点。
+    *   连接到访客网络的客户端将被重定向到此指定URL。根据具体的本地认证设置（可能因固件或自定义配置而异），他们可能在查看页面后或执行简单操作（如单击按钮）后立即获得访问权限。
 
-此设置可为访客提供受控且隔离的网络，同时要求他们通过您的门户才能访问。
+这种方法为访客提供了一个受控且隔离的网络，同时要求他们通过您配置的门户或展示页面才能访问。记住在 LuCI 中保存并应用您的更改。
 
 ### 问题排查
 
@@ -103,8 +120,7 @@ ApFree WiFiDog 会记录日志消息，这些消息可以为其操作和任何�
 
 *   **特定设备的门户或认证问题：**
     *   **MAC 地址列表：** ApFree WiFiDog 可以包含受信任（白名单）和不受信任（黑名单）的 MAC 地址列表。
-        *   使用 `wdctlx show_trusted_mac` 查看始终允许的 MAC 地址。
-        *   使用 `wdctlx show_untrusted_mac` 查看始终阻止的 MAC 地址。
+        *   使用 `wdctlx show mac` 查看已配置的 MAC 地址 (例如，根据系统设置可能是受信任的或已阻止的)。
         如果特定设备的行为异常，请检查这些列表。
 
 #### 使用 `wdctlx` 进行诊断
@@ -115,7 +131,7 @@ ApFree WiFiDog 附带一个名为 `wdctlx` (WiFiDog Control) 的命令行实用�
 *   `wdctlx status client`：列出所有已连接和已认证的客户端。
 *   `wdctlx show domain`：显示当前的受信任域列表。
 *   `wdctlx show wildcard_domain`：显示当前的受信任通配符域列表。
-*   `wdctlx show mac`：显示受信任的 MAC 地址。
+*   `wdctlx show mac`：显示 MAC 地址列表。
 *   `wdctlx add <domain|wildcard_domain|mac> <value1,value2...>`: 添加指定的值到信任的域名、通配符域名或 MAC 地址列表。
 *   `wdctlx del <domain|wildcard_domain|mac> <value1,value2...>`: 从信任的域名、通配符域名或 MAC 地址列表中删除指定的值。
 *   `wdctlx clear <domain|wildcard_domain|mac>`: 清除指定的信任列表（域名、通配符域名或 MAC 地址）中的所有条目。

--- a/README-zh.md
+++ b/README-zh.md
@@ -168,6 +168,12 @@ ApFree WiFiDog 附带一个名为 `wdctlx` (WiFiDog Control) 的命令行实用�
     2.  **认证服务器通信：** 客户端与认证服务器交互（例如，输入凭据、单击按钮或付款）。然后，认证服务器验证客户端。
     3.  **防火墙更新：** 成功认证后，认证服务器会通知 ApFree WiFiDog。然后，ApFree WiFiDog 会更新防火墙规则（例如，将客户端的 IP 或 MAC 地址添加到允许列表或标记其连接），以在指定持续时间内或根据定义的策略授予客户端互联网访问权限。客户端状态和会话有效性会定期检查。
 
+### 认证服务器API
+
+对于希望将 ApFree WiFiDog 与自定义认证服务器集成，或希望详细了解通信协议的开发人员，我们提供了专门的 API 文档。该文档概述了 WiFiDog 与认证服务器之间通信所使用的 Ping (心跳)、Counters (计数器 V2) 和 WebSocket 接口。
+
+[查看认证服务器API文档 (中文)](AUTH_SERVER_API_ZH.md)
+
 ### 在云认证模式下使用 ApFree WiFiDog
 
 要在云认证模式下运行 ApFree WiFiDog，您必须首先建立一个认证服务器。设置完成后，通过在配置文件中指定其 IP 地址或域名来配置 ApFree WiFiDog 连接到您的服务器。

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ This section provides a brief overview of ApFree WiFiDog's internal workings.
     2.  **Authentication Server Communication:** The client interacts with the authentication server (e.g., enters credentials, clicks a button, or makes a payment). The authentication server then validates the client.
     3.  **Firewall Update:** Upon successful authentication, the authentication server notifies ApFree WiFiDog. ApFree WiFiDog then updates the firewall rules (e.g., adds the client's IP or MAC address to an allowed list or marks their connections) to grant the client internet access for a specified duration or according to the defined policy. Client status and session validity are periodically checked.
 
+### Authentication Server API
+
+For developers looking to integrate ApFree WiFiDog with a custom authentication server, or to understand the communication protocol in detail, a dedicated API documentation is available. This document outlines the Ping, Counters (V2), and WebSocket interfaces used for communication between WiFiDog and the authentication server.
+
+[View the Authentication Server API Documentation (English)](AUTH_SERVER_API_EN.md)
+
 ### Using ApFree WiFiDog in Cloud Auth Mode
 
 To operate ApFree WiFiDog in cloud auth mode, you must first establish an authentication server. Once set up, configure ApFree WiFiDog to connect to your server by specifying its IP address or domain in the configuration file.

--- a/README.md
+++ b/README.md
@@ -32,53 +32,70 @@ ApFree WiFiDog is an open-source, high-performance captive portal solution for H
 4. **Long Connection Support**: Accommodates long connections, including WebSocket and MQTT, for real-time communication.
 5. **Flexible Authentication**: Offers both local and cloud-based authentication methods, catering to diverse user needs.
 6. **Advanced Rules Management**: Enables dynamic management of access rules, including MAC address and IP/domain management, without requiring restarts.
+7. **Active Support**: Benefits from active community support and responsive issue resolution.
+8. **eBPF-based Traffic Control & DPI**: Leverages eBPF for efficient traffic control and Deep Packet Inspection (DPI) capabilities.
 
 ### Installation
 
-Before installing any packages, it's recommended to update the package lists:
-```bash
-opkg update
-```
+The package manager commands for OpenWrt vary depending on the version.
 
-To install ApFree WiFiDog on OpenWrt, use the following command:
-```bash
-opkg install apfree-wifidog
-```
+**For latest OpenWrt versions (typically using `apk`):**
+1. Update package lists:
+   ```bash
+   apk update
+   ```
+2. Install ApFree WiFiDog:
+   ```bash
+   apk add apfree-wifidog
+   ```
 
-For the LuCI web interface, install the following package:
-```bash
-opkg install luci-app-apfree-wifidog
-```
+**For older OpenWrt versions (typically using `opkg`):**
+1. Update package lists:
+   ```bash
+   opkg update
+   ```
+2. Install ApFree WiFiDog:
+   ```bash
+   opkg install apfree-wifidog
+   ```
+
+**LuCI Web Interface:**
+The `luci-app-apfree-wifidog` package is **not** installed using the commands above. For guidance on setting up the LuCI web interface, please refer to the "LuCI Integration" section, which recommends using the `chawrt` project or integrating LuCI from the main `luci` repository if you are building your own firmware.
 
 ### LuCI Integration
 
-For simplified configuration, ApFree WiFiDog includes a LuCI interface. Manage your settings easily through a user-friendly web interface via the [luci-app-apfree-wifidog repository](https://github.com/liudf0716/luci-app-apfree-wifidog).
+For simplified configuration, ApFree WiFiDog has a LuCI interface. While the `luci-app-apfree-wifidog` package was previously standalone, it is now integrated into the main `luci` repository available at [https://github.com/liudf0716/luci](https://github.com/liudf0716/luci).
+
+**Recommended Setup:**
+We recommend users adopt the **`chawrt`** project for their OpenWrt setup, which can be found at [https://github.com/liudf0716/chawrt](https://github.com/liudf0716/chawrt). The `chawrt` project includes `luci-app-apfree-wifidog` and provides a comprehensive, ready-to-use OpenWrt firmware solution with ApFree WiFiDog integrated. Using `chawrt` is the easiest way to get started with a fully configured system.
+
+If you are building your own firmware or prefer manual installation, you can find the LuCI application as part of the `luci` repository mentioned above. However, for most users, **`chawrt`** offers a more streamlined experience.
 
 ### Basic Usage Example: Guest Network
 
-A common use case for ApFree WiFiDog is to set up a guest WiFi network that requires users to authenticate via a captive portal before gaining full internet access. Here's a general outline of the steps involved:
+Configuring ApFree WiFiDog is best done using the `luci-app-apfree-wifidog` web interface, which provides a user-friendly way to manage all settings. Manual editing of configuration files is discouraged.
 
-1.  **Set up a Guest Network Interface in OpenWrt:**
-    *   This typically involves creating a new network interface (e.g., `guestnet`) in your OpenWrt router's network configuration.
-    *   You might assign this interface to a separate VLAN or a different WiFi SSID specifically for guests.
-    *   Ensure this guest network has DHCP enabled to assign IP addresses to clients but initially does not allow general internet access through firewall rules (ApFree WiFiDog will manage this).
+Here are two common scenarios:
 
-2.  **Configure ApFree WiFiDog:**
-    *   Edit the ApFree WiFiDog configuration file (e.g., `/etc/wifidog.conf` or `/etc/wifidogx.conf`).
-    *   Set the `GatewayInterface` option to the name of your guest network interface (e.g., `GatewayInterface guestnet`).
-    *   Configure the authentication server details by setting `AuthServerHostname`, `AuthServerPort`, and `AuthServerPath` to point to your captive portal's authentication service. For example:
-        ```
-        AuthServerHostname auth.example.com
-        AuthServerPort 80
-        AuthServerPath /wifidog/
-        ```
+1.  **Cloud Authentication Mode:**
+    *   This mode requires an external authentication server.
+    *   **Steps via LuCI:**
+        *   Navigate to the ApFree WiFiDog configuration page in LuCI.
+        *   **Authentication Server Settings:** Configure the `Hostname`, `Port`, and `Path` for your authentication server.
+        *   **Gateway Settings:** Ensure the `Gateway Interface` is correctly set to your guest network interface (e.g., `br-guest`).
+        *   **Advanced Settings:** For real-time communication and status updates (often needed by cloud solutions), enable and configure `WebSocket Support` (e.g., specify WebSocket URL/Path).
+    *   Clients connecting to the guest network will be redirected to your cloud authentication portal. After successful authentication, they will be granted internet access.
 
-3.  **Client Connection and Redirection:**
-    *   When a client connects to your guest WiFi network, their HTTP(S) traffic will be intercepted by ApFree WiFiDog.
-    *   They will be redirected to the authentication portal specified by your `AuthServer` settings.
-    *   After successful authentication, ApFree WiFiDog will allow them internet access based on the rules and duration provided by the authentication server.
+2.  **Local Authentication Mode (Splash Page Only):**
+    *   This mode does not require an external authentication server and is typically used for simpler scenarios like displaying a welcome page or terms of service before granting access.
+    *   **Steps via LuCI:**
+        *   Navigate to the ApFree WiFiDog configuration page in LuCI.
+        *   **Gateway Settings:** Ensure the `Gateway Interface` is correctly set to your guest network interface (e.g., `br-guest`).
+        *   **Authentication Mode:** Select a local or splash page mode if available, or ensure no external `AuthServer` is configured.
+        *   **Redirect URL / Splash Page URL:** Configure the `Redirect URL` (or similar field) to point to your desired local splash page or an external informational page. This is the page users will see before being granted access. For a simple "click-to-continue" setup, this might be a page you host on the router itself or a simple external site.
+    *   Clients connecting to the guest network will be redirected to this specified URL. Depending on the specific local authentication setup (which might vary by firmware or custom configurations), they might be granted access immediately after viewing the page or after a simple action like clicking a button.
 
-This setup provides a controlled and isolated network for guests while requiring them to pass through your portal for access.
+This approach provides a controlled and isolated network for guests while requiring them to pass through your configured portal or splash page for access. Remember to save and apply your changes in LuCI.
 
 ### Troubleshooting
 
@@ -104,8 +121,7 @@ ApFree WiFiDog logs messages that can provide valuable insights into its operati
 
 *   **Device-Specific Portal or Authentication Issues:**
     *   **MAC Address Lists:** ApFree WiFiDog can have lists of trusted (whitelisted) and untrusted (blacklisted) MAC addresses.
-        *   Use `wdctlx show_trusted_mac` to see MAC addresses that are always allowed.
-        *   Use `wdctlx show_untrusted_mac` to see MAC addresses that are always blocked.
+        *   Use `wdctlx show mac` to see MAC addresses that are configured (e.g., trusted or blocked based on system setup).
         Check these lists if a specific device is behaving unexpectedly.
 
 #### Using `wdctlx` for Diagnostics
@@ -116,7 +132,7 @@ ApFree WiFiDog comes with a command-line utility called `wdctlx` (WiFiDog Contro
 *   `wdctlx status client`: Lists all connected and authenticated clients.
 *   `wdctlx show domain`: Displays the current list of trusted domains.
 *   `wdctlx show wildcard_domain`: Displays the current list of trusted wildcard domains.
-*   `wdctlx show mac`: Displays trusted MAC addresses.
+*   `wdctlx show mac`: Displays the MAC address list.
 *   `wdctlx add <domain|wildcard_domain|mac> <value1,value2...>`: Adds specified values to the trusted domain, wildcard domain, or MAC list.
 *   `wdctlx del <domain|wildcard_domain|mac> <value1,value2...>`: Deletes specified values from the trusted domain, wildcard domain, or MAC list.
 *   `wdctlx clear <domain|wildcard_domain|mac>`: Clears all entries from the specified trusted list (domain, wildcard domain, or MAC).


### PR DESCRIPTION
Docs: Add Authentication Server API Documentation

I've created new detailed API documentation for ApFree WiFiDog's communication
with authentication servers. This includes specifications for the Ping,
Counters (V2 JSON), and WebSocket interfaces.

The documentation is provided in two new files:
- AUTH_SERVER_API_EN.md (English)
- AUTH_SERVER_API_ZH.md (Chinese)

I've also updated README.md and README-zh.md to include sections that link
to these new API documentation files.

This addresses your request to document these interfaces for
developers building or integrating with authentication servers.