### PR TITLE
Docs: Add prominent links for Auth Server API in READMEs

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -9,7 +9,7 @@
 [![OpenWRT](https://img.shields.io/badge/Platform-%20OpenWRT%20-brightgreen.svg?style=plastic)](https://github.com/openwrt) 
 [![Join the QQ Group](https://img.shields.io/badge/chat-qq%20group-brightgreen.svg)](https://jq.qq.com/?_wv=1027&k=4ADDSev)
 
-[English Version](README.md) | [中文版本](README-zh.md)
+[English Version](README.md) | [中文版本](README-zh.md) | [认证服务器API](AUTH_SERVER_API_ZH.md)
 
 ## ApFree WiFiDog: 高性能 HTTP(S) 认证门户解决方案
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![OpenWRT](https://img.shields.io/badge/Platform-%20OpenWRT%20-brightgreen.svg?style=plastic)](https://github.com/openwrt) 
 [![Join the QQ Group](https://img.shields.io/badge/chat-qq%20group-brightgreen.svg)](https://jq.qq.com/?_wv=1027&k=4ADDSev)
 
-[English Version](README.md) | [中文版本](README-zh.md)
+[English Version](README.md) | [中文版本](README-zh.md) | [Auth Server API](AUTH_SERVER_API_EN.md)
 
 ## ApFree WiFiDog: A High-Performance Captive Portal Solution for HTTP(S)
 


### PR DESCRIPTION
I've added direct links to the Authentication Server API documentation at the top of both README.md and README-zh.md, next to the language selection links.

This makes the API documentation more accessible for you. The existing links within the dedicated API sections of the READMEs remain unchanged.