### PR TITLE
Fix: Memory leak in client IP retrieval in auth callback

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -869,6 +869,7 @@ ev_http_callback_auth(struct evhttp_request *req, void *arg)
         // Ensure gw_setting is not NULL before dereferencing
         if (gw_setting && br_arp_get_mac(gw_setting, remote_host, actual_mac_buffer)) {
             mac = safe_strdup(actual_mac_buffer); // mac is now alloc'd
+            free(peer_ip_temp); // Free peer_ip_temp after successful MAC retrieval
         } else {
             // Provide a more specific error if gw_setting was the issue
             if (!gw_setting) { // This case should ideally be caught by gw_id check
@@ -876,6 +877,7 @@ ev_http_callback_auth(struct evhttp_request *req, void *arg)
             } else {
                  evhttp_send_error(req, 200, "Failed to retrieve your MAC address (ARP/NDP failed)");
             }
+            free(peer_ip_temp); // Free peer_ip_temp in the error path
             // remote_host will be freed at CLEAN_UP
             goto CLEAN_UP;
         }


### PR DESCRIPTION
In the `ev_http_callback_auth` function within `src/http.c`, when client IP and MAC are not provided in the query parameters, the client's IP is fetched using `ev_http_connection_get_peer`. This function allocates memory for the IP string.

The fetched IP string (`peer_ip_temp`) was then duplicated using `safe_strdup` into `remote_host`. However, the original memory allocated for `peer_ip_temp` was not subsequently freed.

This commit fixes the leak by ensuring that `free(peer_ip_temp)` is called after its value has been duplicated into `remote_host` or if an error occurs preventing its use, specifically within the conditional block that handles missing `client_ip` or `client_mac` parameters.