### PR TITLE
Hi there! Here's an update on the memory management for client copies…

### DIFF
--- a/src/centralserver.c
+++ b/src/centralserver.c
@@ -794,7 +794,7 @@ client_counter_request_reply(t_authresponse *authresponse,
     }
 
     // Free the duplicate client data
-    client_free_node(client);
+    // client_free_node(client); // Removed
 }
 
 /**
@@ -830,9 +830,7 @@ process_auth_server_counter(struct evhttp_request *req, void *ctx)
         debug(LOG_ERR, "Failed to parse auth server response for client %s", 
               client ? client->ip : "unknown");
         
-        if (client) {
-            client_free_node(client);
-        }
+        // if (client) { // client_free_node(client); } // Removed
         ((struct wd_request_context *)ctx)->data = NULL;
     }
 }

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -634,6 +634,10 @@ get_gw_clients_counter(t_gateway_setting *gw_setting, t_client *worklist)
 
     while (gw_setting) {
         json_object *gw_obj = json_object_new_object();
+        if (!gw_obj) {
+            debug(LOG_ERR, "Could not create gw_obj for gateway %s", gw_setting->gw_id);
+            continue;
+        }
         json_object_object_add(gw_obj, "gw_id", json_object_new_string(gw_setting->gw_id));
 		json_object_object_add(gw_obj, "gw_channel", json_object_new_string(gw_setting->gw_channel));
         json_object *client_array = json_object_new_array();
@@ -789,7 +793,6 @@ ev_fw_sync_with_authserver(struct wd_request_context *context)
 			char *uri = get_auth_uri(REQUEST_TYPE_COUNTERS, ONLINE_CLIENT, p1);
 			if (!uri) {
 				debug(LOG_ERR, "Could not get auth uri!");
-				client_free_node(p1);
 				continue;
 			} 
 
@@ -798,13 +801,13 @@ ev_fw_sync_with_authserver(struct wd_request_context *context)
 			struct evhttp_connection *evcon = NULL;
 			struct evhttp_request *req = NULL;
 			context->data = p1; // free p1 in process_auth_server_counter
-			if (!wd_make_request(context, &evcon, &req, process_auth_server_counter))
+			if (!wd_make_request(context, &evcon, &req, process_auth_server_counter)) {
 				evhttp_make_request(evcon, req, EVHTTP_REQ_GET, uri);
-			else
-				client_free_node(p1);
+			}
 			free(uri);
 		}
 	}
+	client_list_destroy(worklist);
 }
 
 void 


### PR DESCRIPTION
… in auth sync.

This change addresses a potential double-free issue related to client node copies created in `ev_fw_sync_with_authserver` (firewall.c) and processed by callbacks in `centralserver.c`.

The core changes are:

1.  **`centralserver.c` (`process_auth_server_counter`, `client_counter_request_reply`):**
    *   I removed calls to `client_free_node(client)` where `client` was obtained from `context->data`. These callbacks now only use the client data but do not manage the lifecycle of the client node copy itself.
    *   This ensures that the client node (which is a copy from the `worklist` in `ev_fw_sync_with_authserver`) is not freed by the callback.

2.  **`firewall.c` (`ev_fw_sync_with_authserver`):**
    *   This function is now solely responsible for the lifecycle of the `worklist` (a duplicated list of clients) and all its nodes.
    *   It ensures `client_list_destroy(worklist)` is called at the end of the function.
    *   It does not call `client_free_node()` for nodes from `worklist` within its loop, even in error conditions like `get_auth_uri()` failure or `wd_make_request()` failure. These nodes are now correctly cleaned up by `client_list_destroy(worklist)`.

This revised approach centralizes the memory management of the `worklist` nodes within `ev_fw_sync_with_authserver`, preventing double-frees that could occur if both the callback and `client_list_destroy` attempted to free the same client node copy.