### PR TITLE
Refactor: Remove unnecessary include from mqtt_thread.h

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -14,7 +14,7 @@
 #include "auth.h"
 #include "http.h"
 #include "client_list.h"
-#include "wdctl_thread.h"
+#include "wdctlx_thread.h"
 #include "ping_thread.h"
 #include "util.h"
 #include "tls_thread.h"

--- a/src/http.c
+++ b/src/http.c
@@ -22,7 +22,7 @@
 #include "gateway.h"
 #include "safe.h"
 #include "util.h"
-#include "wdctl_thread.h"
+#include "wdctlx_thread.h"
 #include "wd_util.h"
 #include "version.h"
 #include "wd_client.h"

--- a/src/mqtt_thread.c
+++ b/src/mqtt_thread.c
@@ -6,7 +6,7 @@
 
 #include "common.h"
 #include "mqtt_thread.h"
-#include "wdctl_thread.h"
+#include "wdctlx_thread.h"
 #include "conf.h"
 #include "debug.h"
 #include "safe.h"

--- a/src/mqtt_thread.h
+++ b/src/mqtt_thread.h
@@ -7,7 +7,6 @@
 #ifndef	_MQTT_THREAD_H_
 #define	_MQTT_THREAD_H_
 
-#include "wdctl_thread.h"
 #include "conf.h"
 
 void set_trusted_op(void *mosq, const char *type, const char *value, const int req_id, const s_config *config);


### PR DESCRIPTION
I removed the inclusion of "wdctlx_thread.h" from "src/mqtt_thread.h". This header was not directly needed for the declarations within "mqtt_thread.h" itself.

The functions and types from "wdctlx_thread.h" are used by "mqtt_thread.c", where the include remains. This change helps reduce header coupling and can improve compilation times for files that only include "mqtt_thread.h" for its interface.